### PR TITLE
Enable pagination in Blog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/imfing/hextra-starter-template
 
 go 1.21
 
-require github.com/imfing/hextra v0.9.8-0.20250721201644-7b2774315999 // indirect
+require github.com/imfing/hextra v0.9.8-0.20250724212617-46290e10e71d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.9.8-0.20250721201644-7b2774315999 h1:SrxfJ1EWZtiCf6DCTt3kglZK4VVAxsNp/09jzo2IjoQ=
-github.com/imfing/hextra v0.9.8-0.20250721201644-7b2774315999/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.9.8-0.20250724212617-46290e10e71d h1:jt/r1pdnW9Lrw2kI12KCEBwV3gJH83UOycdjB5Vl/sE=
+github.com/imfing/hextra v0.9.8-0.20250724212617-46290e10e71d/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -120,6 +120,8 @@ params:
       # date | lastmod | publishDate | title | weight
       sortBy: publishDate
       sortOrder: desc # or "asc"
+      # Pagination
+      pagerSize: 5
     article:
       displayPagination: true
 


### PR DESCRIPTION
This pull request includes two changes: an update to a dependency version in the `go.mod` file and the addition of a pagination configuration in the `hugo.yaml` file.

Dependency update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L5-R5): Updated the version of `github.com/imfing/hextra` to `v0.9.8-0.20250724212617-46290e10e71d` to ensure compatibility with the latest changes.

Configuration enhancement:

* [`hugo.yaml`](diffhunk://#diff-5928f4025679c9eee397ca3795367f71f667ce1f25018b7f7ae7c574da1f2f08R123-R124): Added a `pagerSize` parameter under `params` to configure pagination, setting it to `5`. This improves the control over the number of items displayed per page.